### PR TITLE
Fix Element overlay in pop-up.

### DIFF
--- a/index.css
+++ b/index.css
@@ -269,6 +269,7 @@ li {
 .overlay:target {
   visibility: visible;
   opacity: 1;
+  z-index: 1;
 }
 
 .popup {


### PR DESCRIPTION
Issue : The element behind the pop-up appears in pop-up and that shouldn't be
See the Attached images below.
Fix: Increasing the Z-index of the pop-up will fix this.

![before](https://user-images.githubusercontent.com/53273271/102297791-e45dad00-3f75-11eb-9a50-51e834d00cc7.JPG)
![After](https://user-images.githubusercontent.com/53273271/102297804-e7f13400-3f75-11eb-9198-6a1dbe3022bc.JPG)

